### PR TITLE
add addScopes method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+### v0.2.0
+
+* Add `Query::addScope` method for custom scopes
+* Create `BootableTraits` trait
+* Create `QueriesPosts` trait

--- a/README.md
+++ b/README.md
@@ -57,13 +57,15 @@ class FeaturedPostsQuery extends Query
     public function setup( Builder $builder ): Builder
     {
         // Setup a tax_query for posts with the 'featured' term.
-        $featured = [
-            'taxonomy' => 'featured',
-            'fields'   => 'slugs',
-            'terms'    => [ 'featured' ],
+        $tax_query = [
+            [
+                'taxonomy' => 'featured',
+                'fields'   => 'slugs',
+                'terms'    => [ 'featured' ],
+            ],
         ];
 
-        return $builder->taxonomy( $featured );
+        return $builder->where( 'tax_query', $tax_query );
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -90,6 +90,44 @@ $query = new Featured( $args );
 $results = $query->limit( 3 )->get();
 ```
 
+### Custom Scopes
+
+Custom scopes can be added to the global `Query` using the static `addScope` method. One of the simplest ways to add a scope is with a closure.
+
+```php
+// Create a new scope with a closure.
+Query::addScope( 'events', function( Builder $builder ) {
+    return $builder->where( 'post_type', 'event' );
+} );
+
+// Call the scope when needed.
+$results = Query::events()->limit( 3 );
+```
+
+#### Custom Scope Classes
+
+Custom scope classes can be added to the global `Query`. The custom scope class will need to implement the `Scope` interface and contain the required `apply` method.
+The `apply` method should accept the query `Builder` as the first argument and any optional arguments passed via the scope.
+Once added to the `Query` class the scope will be available by the class name with the first letter lowecase.
+
+```php
+// Create a custom scope class.
+use Query\Scope;
+use Query\Builder;
+
+class PostID implements Scope {
+    public function apply( Builder $builder, $id = null ) {
+        return $builder->where( 'p', $id );
+    }
+}
+
+// Add the scope to the Query.
+Query::addScope( new PostID );
+
+// Use the scope in the Query.
+$results = Query::postID( 123 )->get();
+```
+
 ## Notes
 
 * The library is still in active development and not intended for production use.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# WordPress Query Builder v0.1.0
+# WordPress Query Builder v0.2.0
 
 > A fluent interface for creating WordPress Queries
 

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,11 @@
             "Query\\": "src/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "Query\\Tests\\": "tests/"
+        }
+    },
     "require": {
         "php": ">=7.2"
     },

--- a/src/Concerns/BootsTraits.php
+++ b/src/Concerns/BootsTraits.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Query\Concerns;
+
+use ReflectionClass;
+
+trait BootsTraits
+{
+    /**
+     * Bootstrap bootable traits.
+     *
+     * @return void
+     */
+    public function bootTraits()
+    {
+        // Get traits associated to the class.
+        $traits = (new ReflectionClass(static::class))->getTraitNames();
+
+        // Loop over traits and call their bootable method.
+        foreach ($traits as $trait) {
+            // Create the bootable method string.
+            $method = 'boot' . (new ReflectionClass($trait))->getShortName();
+
+            // Skip, if no bootable method available.
+            if (!method_exists($this, $method)) {
+                continue;
+            }
+
+            // Call the bootable method.
+            $this->{$method}();
+        }
+    }
+}

--- a/src/Concerns/HasScopes.php
+++ b/src/Concerns/HasScopes.php
@@ -9,6 +9,13 @@ use ReflectionClass;
 trait HasScopes
 {
     /**
+     * Scopes added to the Query.
+     *
+     * @var array
+     */
+    private static $scopes = [];
+
+    /**
      * The available scope objects.
      *
      * @var array
@@ -21,6 +28,18 @@ trait HasScopes
      * @var array
      */
     private $aliases = [];
+
+    /**
+     * Add a scope to the Query.
+     *
+     * @param \Query\Scope|string $scope
+     *
+     * @return void
+     */
+    public static function addScope($scope)
+    {
+        static::$scopes[] = $scope;
+    }
 
     /**
      * Setup scopes.

--- a/src/Concerns/HasScopes.php
+++ b/src/Concerns/HasScopes.php
@@ -42,6 +42,16 @@ trait HasScopes
     }
 
     /**
+     * Boot scopes to Query.
+     *
+     * @return void
+     */
+    protected function bootHasScopes()
+    {
+        $this->buildScopes(static::$scopes);
+    }
+
+    /**
      * Setup scopes.
      *
      * @return void

--- a/src/Concerns/QueriesPosts.php
+++ b/src/Concerns/QueriesPosts.php
@@ -5,40 +5,37 @@ namespace Query\Concerns;
 trait QueriesPosts
 {
     /**
-     * Post Scopes
-     *
-     * @var array
-     */
-    private $postScopes = [
-        \Query\Scopes\Author::class,
-        \Query\Scopes\AuthorIn::class,
-        \Query\Scopes\AuthorNotIn::class,
-        \Query\Scopes\Comments::class,
-        \Query\Scopes\Meta::class,
-        \Query\Scopes\Order::class,
-        \Query\Scopes\OrderBy::class,
-        \Query\Scopes\Page::class,
-        \Query\Scopes\ParentIn::class,
-        \Query\Scopes\ParentNotIn::class,
-        \Query\Scopes\Password::class,
-        \Query\Scopes\Post::class,
-        \Query\Scopes\PostIn::class,
-        \Query\Scopes\PostNotIn::class,
-        \Query\Scopes\PostParent::class,
-        \Query\Scopes\PostStatus::class,
-        \Query\Scopes\PostType::class,
-        \Query\Scopes\PostsPerPage::class,
-        \Query\Scopes\Search::class,
-        \Query\Scopes\Taxonomy::class,
-    ];
-
-    /**
      * Add Post Scopes to the query on boot.
      *
      * @var array
      */
     protected function bootQueriesPosts()
     {
-        array_walk($this->postScopes, [$this, 'addScope']);
+        $scopes = [
+            new \Query\Scopes\Author,
+            new \Query\Scopes\AuthorIn,
+            new \Query\Scopes\AuthorNotIn,
+            new \Query\Scopes\Comments,
+            new \Query\Scopes\Meta,
+            new \Query\Scopes\Order,
+            new \Query\Scopes\OrderBy,
+            new \Query\Scopes\Page,
+            new \Query\Scopes\ParentIn,
+            new \Query\Scopes\ParentNotIn,
+            new \Query\Scopes\Password,
+            new \Query\Scopes\Post,
+            new \Query\Scopes\PostIn,
+            new \Query\Scopes\PostNotIn,
+            new \Query\Scopes\PostParent,
+            new \Query\Scopes\PostStatus,
+            new \Query\Scopes\PostType,
+            new \Query\Scopes\PostsPerPage,
+            new \Query\Scopes\Search,
+            new \Query\Scopes\Taxonomy,
+        ];
+
+        foreach ($scopes as $scope) {
+            $this->addScope($scope);
+        }
     }
 }

--- a/src/Concerns/QueriesPosts.php
+++ b/src/Concerns/QueriesPosts.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Query\Concerns;
+
+trait QueriesPosts
+{
+    /**
+     * Post Scopes
+     *
+     * @var array
+     */
+    private $postScopes = [
+        \Query\Scopes\Author::class,
+        \Query\Scopes\AuthorIn::class,
+        \Query\Scopes\AuthorNotIn::class,
+        \Query\Scopes\Comments::class,
+        \Query\Scopes\Meta::class,
+        \Query\Scopes\Order::class,
+        \Query\Scopes\OrderBy::class,
+        \Query\Scopes\Page::class,
+        \Query\Scopes\ParentIn::class,
+        \Query\Scopes\ParentNotIn::class,
+        \Query\Scopes\Password::class,
+        \Query\Scopes\Post::class,
+        \Query\Scopes\PostIn::class,
+        \Query\Scopes\PostNotIn::class,
+        \Query\Scopes\PostParent::class,
+        \Query\Scopes\PostStatus::class,
+        \Query\Scopes\PostType::class,
+        \Query\Scopes\PostsPerPage::class,
+        \Query\Scopes\Search::class,
+        \Query\Scopes\Taxonomy::class,
+    ];
+
+    /**
+     * Add Post Scopes to the query on boot.
+     *
+     * @var array
+     */
+    protected function bootQueriesPosts()
+    {
+        array_walk($this->postScopes, [$this, 'addScope']);
+    }
+}

--- a/src/Query.php
+++ b/src/Query.php
@@ -10,34 +10,6 @@ class Query
     use HasScopes;
 
     /**
-     * Scopes available to the query.
-     *
-     * @var array
-     */
-    protected $scopes = [
-        \Query\Scopes\Author::class,
-        \Query\Scopes\AuthorIn::class,
-        \Query\Scopes\AuthorNotIn::class,
-        \Query\Scopes\Comments::class,
-        \Query\Scopes\Meta::class,
-        \Query\Scopes\Order::class,
-        \Query\Scopes\OrderBy::class,
-        \Query\Scopes\Page::class,
-        \Query\Scopes\ParentIn::class,
-        \Query\Scopes\ParentNotIn::class,
-        \Query\Scopes\Password::class,
-        \Query\Scopes\Post::class,
-        \Query\Scopes\PostIn::class,
-        \Query\Scopes\PostNotIn::class,
-        \Query\Scopes\PostParent::class,
-        \Query\Scopes\PostStatus::class,
-        \Query\Scopes\PostType::class,
-        \Query\Scopes\PostsPerPage::class,
-        \Query\Scopes\Search::class,
-        \Query\Scopes\Taxonomy::class,
-    ];
-
-    /**
      * The Query Builder object.
      *
      * @var Builder
@@ -61,7 +33,7 @@ class Query
      */
     public function __construct(array $query = [])
     {
-        $this->buildScopes($this->scopes);
+        $this->buildScopes(static::$scopes);
 
         $this->builder = $this->setup(new Builder($query));
     }

--- a/src/Query.php
+++ b/src/Query.php
@@ -3,11 +3,13 @@
 namespace Query;
 
 use Query\Builder;
+use Query\Concerns\BootsTraits;
 use Query\Concerns\HasScopes;
+use Query\Concerns\QueriesPosts;
 
 class Query
 {
-    use HasScopes;
+    use BootsTraits, HasScopes, QueriesPosts;
 
     /**
      * The Query Builder object.
@@ -33,8 +35,10 @@ class Query
      */
     public function __construct(array $query = [])
     {
-        $this->buildScopes(static::$scopes);
+        // Boot traits.
+        $this->bootTraits();
 
+        // Setup the Builder instances.
         $this->builder = $this->setup(new Builder($query));
     }
 

--- a/src/Query.php
+++ b/src/Query.php
@@ -38,6 +38,9 @@ class Query
         // Boot traits.
         $this->bootTraits();
 
+        // Build scopes.
+        $this->buildScopes();
+
         // Setup the Builder instances.
         $this->builder = $this->setup(new Builder($query));
     }

--- a/tests/Unit/Query/Concerns/HasScopesTest.php
+++ b/tests/Unit/Query/Concerns/HasScopesTest.php
@@ -1,0 +1,18 @@
+<?php
+
+use Query\Query;
+use Query\Builder;
+use Query\Scope;
+use PHPUnit\Framework\TestCase;
+
+class HasScopesTest extends TestCase
+{
+    public function test_query_can_add_scopes()
+    {
+        Query::addScope(\Query\Scopes\Search::class);
+
+        $params = Query::search('test')->getBuilder()->getParameters();
+
+        $this->assertEquals(['s' => 'test'], $params);
+    }
+}

--- a/tests/Unit/Query/Concerns/HasScopesTest.php
+++ b/tests/Unit/Query/Concerns/HasScopesTest.php
@@ -7,19 +7,30 @@ use PHPUnit\Framework\TestCase;
 
 class HasScopesTest extends TestCase
 {
-    public function test_query_can_add_scopes()
-    {
-        Query::addScope(\Query\Scopes\Search::class);
-
-        $result = Query::search('test')->getParameters();
-
-        $this->assertEquals(['s' => 'test'], $result);
-    }
-
     public function test_query_has_bootable_scopes()
     {
         $result = Query::search('test')->post_type('event')->getParameters();
 
         $this->assertEquals(['s' => 'test', 'post_type' => 'event'], $result);
+    }
+
+    public function test_query_can_add_scopes_with_scope_class()
+    {
+        Query::addScope(new \Query\Tests\Unit\Query\Stubs\TestScope);
+
+        $result = Query::test(true)->getParameters();
+
+        $this->assertEquals(['test' => true], $result);
+    }
+
+    public function test_query_can_add_scopes_with_closure()
+    {
+        Query::addScope('test', function (Builder $builder, $var) {
+            return $builder->where('test', $var);
+        });
+
+        $result = Query::test(true)->getParameters();
+
+        $this->assertEquals(['test' => true], $result);
     }
 }

--- a/tests/Unit/Query/Concerns/HasScopesTest.php
+++ b/tests/Unit/Query/Concerns/HasScopesTest.php
@@ -11,8 +11,15 @@ class HasScopesTest extends TestCase
     {
         Query::addScope(\Query\Scopes\Search::class);
 
-        $params = Query::search('test')->getBuilder()->getParameters();
+        $result = Query::search('test')->getParameters();
 
-        $this->assertEquals(['s' => 'test'], $params);
+        $this->assertEquals(['s' => 'test'], $result);
+    }
+
+    public function test_query_has_bootable_scopes()
+    {
+        $result = Query::search('test')->post_type('event')->getParameters();
+
+        $this->assertEquals(['s' => 'test', 'post_type' => 'event'], $result);
     }
 }

--- a/tests/Unit/Query/QueryTest.php
+++ b/tests/Unit/Query/QueryTest.php
@@ -31,7 +31,7 @@ class QueryTest extends TestCase
     {
         $query = Query::where('limit', 10);
 
-        $this->assertEquals(['limit' => 10], $query->getBuilder()->getParameters());
+        $this->assertEquals(['limit' => 10], $query->getParameters());
     }
 
     public function test_query_can_chain_and_proxy_methods_to_builder()
@@ -44,7 +44,7 @@ class QueryTest extends TestCase
             'fields' => 'ids',
         ];
 
-        $this->assertEquals($expected, $query->getBuilder()->getParameters());
+        $this->assertEquals($expected, $query->getParameters());
     }
 
     public function test_query_can_be_passed_through_via_builder_methods()
@@ -53,5 +53,13 @@ class QueryTest extends TestCase
 
         $this->assertNotInstanceOf(Query::class, $parameters);
         $this->assertEquals(['limit' => 10], $parameters);
+    }
+
+    public function test_query_can_return_builder()
+    {
+        $builder = Query::where('limit', 10)->getBuilder();
+
+        $this->assertInstanceOf(Builder::class, $builder);
+        $this->assertEquals(['limit' => 10], $builder->getParameters());
     }
 }

--- a/tests/Unit/Query/Stubs/TestScope.php
+++ b/tests/Unit/Query/Stubs/TestScope.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Query\Tests\Unit\Query\Stubs;
+
+use Query\Scope;
+use Query\Builder;
+
+class TestScope implements Scope
+{
+    public $aliases = [
+        'test',
+    ];
+
+    public function apply(Builder $builder, $value = '')
+    {
+        return $builder->where('test', $value);
+    }
+}


### PR DESCRIPTION
- Allow scopes to be added with a `Query::addScope()` method
- Scopes can be added as instance of a `Scope` class
- Scopes can be added as a Closure with a string key